### PR TITLE
Add professional discoverability for recruiters and search

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -11,13 +11,16 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta
       name="description"
-      content="mission-driven software engineer, volunteer EMT, and parent"
+      content="Senior product engineer at SolarAPP+. Founder of Allo. Climate tech, electrification tools, and full-stack TypeScript — based in Beacon, NY."
     />
 
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://veekasmeansprogress.com" />
     <meta property="og:title" content="veekas ashoka" />
-    <meta property="og:description" content="mission-driven software engineer and volunteer EMT" />
+    <meta
+      property="og:description"
+      content="Senior product engineer at SolarAPP+. Founder of Allo. Climate tech and full-stack TypeScript."
+    />
     <meta property="og:image" content="/latest-headshot.jpeg" />
     <meta property="og:image:alt" content="veekas speaking into a megaphone" />
 

--- a/src/lib/components/AudioMessage.svelte
+++ b/src/lib/components/AudioMessage.svelte
@@ -1,6 +1,23 @@
 <script>
+  import { onMount } from 'svelte';
+
+  /** @type {{ size?: 'default' | 'header' }} */
+  let { size = 'default' } = $props();
+
+  const playLabel = 'Play a short voice hello from veekas';
+  const stopLabel = 'Stop voice hello';
+
   let audio = $state(null);
   let playing = $state(false);
+  let introWaving = $state(false);
+
+  onMount(() => {
+    introWaving = true;
+    const timer = setTimeout(() => {
+      introWaving = false;
+    }, 3000);
+    return () => clearTimeout(timer);
+  });
 
   function toggle() {
     if (!audio) return;
@@ -17,10 +34,16 @@
   type="button"
   class="audio-btn"
   class:playing
+  class:header={size === 'header'}
   onclick={toggle}
-  aria-label={playing ? 'Stop voice message' : 'Play voice message'}
+  title={playing ? stopLabel : playLabel}
+  aria-label={playing ? stopLabel : playLabel}
 >
-  <span class="wave" aria-hidden="true">👋</span>
+  <span
+    class="wave"
+    class:intro-wave={introWaving}
+    aria-hidden="true"
+  >👋🏽</span>
 </button>
 
 <audio
@@ -69,9 +92,47 @@
     transform-origin: 70% 70%;
   }
 
+  .wave.intro-wave,
   .audio-btn.playing .wave,
   .audio-btn:hover .wave {
     animation: wave 0.6s ease-in-out infinite;
+  }
+
+  .audio-btn.header {
+    width: 1em;
+    height: 1em;
+    font-size: inherit;
+    border: 2px solid var(--border);
+    border-radius: 9999px;
+    background: var(--surface);
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgb(0 0 0 / 0.25);
+    transition:
+      border-color 0.15s ease,
+      background 0.15s ease,
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  .audio-btn.header .wave {
+    font-size: 0.52em;
+    line-height: 1;
+  }
+
+  .audio-btn.header:hover,
+  .audio-btn.header.playing {
+    border-color: var(--gold);
+    background: var(--bg);
+    transform: scale(1.1);
+    box-shadow:
+      0 2px 10px rgb(0 0 0 / 0.3),
+      0 0 0 3px rgb(236 182 0 / 0.2);
+  }
+
+  .audio-btn.header:hover .wave,
+  .audio-btn.header.playing .wave,
+  .audio-btn.header .wave.intro-wave {
+    transform-origin: 70% 70%;
   }
 
   @keyframes wave {

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -1,0 +1,100 @@
+<script>
+  /** @type {{ title: string; company: string; period?: string; description: string; technologies: readonly string[]; href?: string }} */
+  let { title, company, period, description, technologies, href } = $props();
+</script>
+
+<article class="card">
+  <header>
+    <div class="card-meta">
+      <span class="company">{company}</span>
+      {#if period}
+        <span class="period">{period}</span>
+      {/if}
+    </div>
+    <h3>
+      {#if href}
+        <a {href} target="_blank" rel="noopener noreferrer">{title}</a>
+      {:else}
+        {title}
+      {/if}
+    </h3>
+  </header>
+  <p>{description}</p>
+  <ul class="tags">
+    {#each technologies as tech}
+      <li>{tech}</li>
+    {/each}
+  </ul>
+</article>
+
+<style>
+  .card {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    transition:
+      border-color 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .card:hover {
+    border-color: var(--gold);
+    transform: translateY(-2px);
+  }
+
+  .card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-size: 0.75rem;
+    color: var(--muted);
+    text-transform: lowercase;
+    letter-spacing: 0.04em;
+  }
+
+  .company {
+    color: var(--gold);
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
+  h3 a {
+    color: var(--text);
+  }
+
+  h3 a:hover {
+    color: var(--gold);
+  }
+
+  p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+    line-height: 1.65;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .tags li {
+    font-size: 0.7rem;
+    color: var(--muted);
+    border: 1px solid var(--border);
+    padding: 0.2rem 0.5rem;
+    border-radius: 2px;
+  }
+</style>

--- a/src/lib/profile.js
+++ b/src/lib/profile.js
@@ -12,7 +12,7 @@ export const skills = [
   'AI products'
 ];
 
-export const tagline = 'senior product engineer · climate tech · allo founder';
+export const tagline = 'senior product engineer · climate + edtech · founder';
 
 export const shortBio =
   'Senior product engineer at SolarAPP+ and founder of Allo, a coaching app for caregivers of young children. Spent two years at Rewiring America building electrification tools — including the Incentive API and Personal Electrification Planner. Seven years in full-stack TypeScript and React, with roots at Arcadia and The Knot.';
@@ -22,54 +22,62 @@ export const metaDescription =
 
 /** @type {readonly { title: string; company: string; period?: string; description: string; technologies: readonly string[]; href?: string }[]} */
 export const projects = [
-  {
-    title: 'Personal Electrification Planner',
-    company: 'Rewiring America',
-    period: '2023–2025',
-    description:
-      'Built the initial frontend for a tool that uses machine learning models to estimate the upfront costs and savings of home electrification.',
-    technologies: ['TypeScript', 'Next.js', 'Node.js', 'PostgreSQL', 'Figma']
-  },
-  {
-    title: 'Incentives API & Savings Calculator',
-    company: 'Rewiring America',
-    period: '2023–2025',
-    description:
-      'Co-managed open-source repos; refactored geolocation models, improved CI/CD data-update workflows, and added endpoints, logging, and analytics.',
-    technologies: ['TypeScript', 'Node.js', 'Terraform', 'GCP', 'PostgreSQL'],
-    href: 'https://github.com/rewiring-america'
-  },
-  {
-    title: 'Allo',
-    company: 'Self',
+    {
+    title: 'Founder',
+    company: 'Alloparent LLC (Allo)',
     period: '2025–present',
     description:
       'Designed and built a childhood speech therapy tool that offers personalized recommendations and support for parents and caregivers.',
     technologies: ['Next.js', 'LangGraph', 'OpenAI API', 'FastAPI', 'Render'],
     href: 'https://allogrow.com'
   },
+  {title: 'Senior Product Engineer',
+    company: 'SolarAPP+',
+    period: '2026–present',
+    description:
+      'Streamlining the permitting process for governments and clean energy installers to save everyone money and time.',
+    technologies: ['PHP, Laravel, Vue, AWS'],
+    href: 'https://www.gosolarapp.org/'
+  },
   {
-    title: 'Healthcare chatbot & provider search',
-    company: 'Freelance',
+    title: 'Software Engineer (Contract)',
+    company: 'Self',
     period: '2025–present',
     description:
-      'Built and improved the chatbot and provider search experience for direct-pay healthcare services.',
+      'Lots of AI-driven full-stack web development. Some agentic workflows that saved people time and money. Built and improved the chatbot and provider search experience for a direct-pay healthcare service.',
     technologies: ['Next.js', 'LangGraph', 'OpenAI API', 'FastAPI', 'Netlify']
   },
   {
-    title: 'Shared infrastructure optimization',
+    title: 'Software Engineer - Personal Electrification Planner',
+    company: 'Rewiring America',
+    period: '2024–2025',
+    description:
+      'Built the initial frontend for a tool that uses machine learning models to estimate the upfront costs and savings of home electrification.',
+    technologies: ['TypeScript', 'Next.js', 'Node.js', 'PostgreSQL', 'Figma']
+  },
+  {
+    title: 'Software Engineer - Incentives API & Savings Calculator',
+    company: 'Rewiring America',
+    period: '2023–2024',
+    description:
+      'Co-managed open-source repos; refactored geolocation models, improved CI/CD data-update workflows, and added endpoints, logging, and analytics.',
+    technologies: ['TypeScript', 'Node.js', 'Terraform', 'GCP', 'PostgreSQL'],
+    href: 'https://github.com/rewiring-america'
+  },
+  {
+    title: 'Software Engineer III',
     company: 'Arcadia',
     period: '2022–2023',
     description:
-      'Optimized shared infrastructure to reduce cloud storage costs across climate-tech products.',
+      'Frontend infrastructure team. Optimized shared infrastructure to reduce cloud storage costs across climate-tech products.',
     technologies: ['TypeScript', 'React', 'Next.js', 'Ruby on Rails', 'AWS']
   },
   {
-    title: 'A/B testing platform & component library',
+    title: 'Software Engineer',
     company: 'The Knot',
     period: '2018–2022',
     description:
-      'Built an internal A/B testing service and REST API for experiments and user bucketing. Led development on a company-wide React component library.',
+      'Worked on the marketplace team. Co-led development of the company-wide React component library. Built an internal A/B testing service and REST API for experiments and user bucketing.',
     technologies: ['React', 'Next.js', 'Node.js', 'Ruby on Rails', 'Jenkins']
   }
 ];
@@ -81,12 +89,15 @@ export function personJsonLd() {
     '@type': 'Person',
     name: 'Veekas Ashoka',
     url: 'https://veekasmeansprogress.com',
-    email: 'veekas.ashoka@gmail.com',
+    email: 'fit-imply-given@duck.com',
     jobTitle: 'Senior Product Engineer',
-    worksFor: {
+    worksFor: [{
       '@type': 'Organization',
       name: 'SolarAPP+'
-    },
+    }, {
+      '@type': 'Organization',
+      name: 'Alloparent LLC'
+    }],
     description: metaDescription,
     knowsAbout: [
       'TypeScript',
@@ -97,20 +108,47 @@ export function personJsonLd() {
       'GraphQL',
       'PostgreSQL',
       'Web Accessibility',
-      'Climate Technology',
+      'Climate',
+      'Clean Energy',
       'Electrification',
+      'Permitting',
       'LangGraph',
-      'OpenAI API'
+      'OpenAI API',
+      'Claude API',
+      'Amazon Bedrock',
+      'FastAPI',
+      'Terraform',
+      'Amazon Web Services',
+      'Google Cloud Platform',
+      'Render',
+      'Netlify',
+      'Figma',
+      'PHP',
+      'Laravel',
+      'Ruby on Rails',
+      'Python',
+      'Docker',
+      'Health Tech',
+      'AI Products',
+      'Caregiver Support',
+      'Speech Therapy',
+      'Direct-Pay Healthcare'
     ],
     sameAs: [
       'https://www.linkedin.com/in/veekas',
       'https://github.com/veekas',
-      'https://allogrow.com'
+      'https://allogrow.com',
     ],
     alumniOf: [
       { '@type': 'Organization', name: 'Rewiring America' },
       { '@type': 'Organization', name: 'Arcadia' },
-      { '@type': 'Organization', name: 'The Knot Worldwide' }
+      { '@type': 'Organization', name: 'The Knot Worldwide' },
+      { '@type': 'Organization', name: 'XO Group' },
+      { '@type': 'Organization', name: 'Fullstack Academy of Code' },
+      { '@type': 'Organization', name: 'Arizona Technology Council' },
+      { '@type': 'Organization', name: 'Arizona State University' },
+      { '@type': 'Organization', name: 'People for the American Way' },
+      { '@type': 'Organization', name: 'Sunrise Movement' }
     ],
     hasCredential: [
       {
@@ -125,14 +163,12 @@ export function personJsonLd() {
 
 /** @type {readonly { href: string; label: string; external?: boolean }[]} */
 export const links = [
+  { href: 'https://allogrow.com', label: 'allo' },
   { href: 'https://www.linkedin.com/in/veekas', label: 'linkedin' },
   { href: 'https://www.github.com/veekas', label: 'github' },
-  { href: 'https://allogrow.com', label: 'allo' },
   { href: 'https://calendly.com/veekas/meet', label: 'calendar' },
   { href: 'mailto:fit-imply-given@duck.com', label: 'email', external: false },
-  { href: '/work', label: 'work', external: false },
-  { href: 'https://i.airbuds.fm/veekas/FJLDpeRRL6', label: 'airbuds' },
-  { href: 'http://www.instagram.com/veekas', label: 'instagram' },
-  { href: 'https://app.thestorygraph.com/profile/veekas', label: 'storygraph' },
-  { href: 'https://strava.app.link/gpIRjM032Yb', label: 'strava' }
+  { href: 'https://app.thestorygraph.com/profile/veekas', label: 'books' },
+  { href: 'https://i.airbuds.fm/veekas/FJLDpeRRL6', label: 'music' },
+  { href: 'https://strava.app.link/gpIRjM032Yb', label: 'workouts' }
 ];

--- a/src/lib/profile.js
+++ b/src/lib/profile.js
@@ -1,0 +1,138 @@
+/** @type {readonly string[]} */
+export const skills = [
+  'TypeScript',
+  'React',
+  'Next.js',
+  'Svelte',
+  'Node.js',
+  'GraphQL',
+  'PostgreSQL',
+  'accessibility',
+  'climate tech',
+  'AI products'
+];
+
+export const tagline = 'senior product engineer · climate tech · allo founder';
+
+export const shortBio =
+  'Senior product engineer at SolarAPP+ and founder of Allo, a coaching app for caregivers of young children. Spent two years at Rewiring America building electrification tools — including the Incentive API and Personal Electrification Planner. Seven years in full-stack TypeScript and React, with roots at Arcadia and The Knot.';
+
+export const metaDescription =
+  'Senior product engineer at SolarAPP+. Founder of Allo. Climate tech, electrification tools, and full-stack TypeScript — based in Beacon, NY.';
+
+/** @type {readonly { title: string; company: string; period?: string; description: string; technologies: readonly string[]; href?: string }[]} */
+export const projects = [
+  {
+    title: 'Personal Electrification Planner',
+    company: 'Rewiring America',
+    period: '2023–2025',
+    description:
+      'Built the initial frontend for a tool that uses machine learning models to estimate the upfront costs and savings of home electrification.',
+    technologies: ['TypeScript', 'Next.js', 'Node.js', 'PostgreSQL', 'Figma']
+  },
+  {
+    title: 'Incentives API & Savings Calculator',
+    company: 'Rewiring America',
+    period: '2023–2025',
+    description:
+      'Co-managed open-source repos; refactored geolocation models, improved CI/CD data-update workflows, and added endpoints, logging, and analytics.',
+    technologies: ['TypeScript', 'Node.js', 'Terraform', 'GCP', 'PostgreSQL'],
+    href: 'https://github.com/rewiring-america'
+  },
+  {
+    title: 'Allo',
+    company: 'Self',
+    period: '2025–present',
+    description:
+      'Designed and built a childhood speech therapy tool that offers personalized recommendations and support for parents and caregivers.',
+    technologies: ['Next.js', 'LangGraph', 'OpenAI API', 'FastAPI', 'Render'],
+    href: 'https://allogrow.com'
+  },
+  {
+    title: 'Healthcare chatbot & provider search',
+    company: 'Freelance',
+    period: '2025–present',
+    description:
+      'Built and improved the chatbot and provider search experience for direct-pay healthcare services.',
+    technologies: ['Next.js', 'LangGraph', 'OpenAI API', 'FastAPI', 'Netlify']
+  },
+  {
+    title: 'Shared infrastructure optimization',
+    company: 'Arcadia',
+    period: '2022–2023',
+    description:
+      'Optimized shared infrastructure to reduce cloud storage costs across climate-tech products.',
+    technologies: ['TypeScript', 'React', 'Next.js', 'Ruby on Rails', 'AWS']
+  },
+  {
+    title: 'A/B testing platform & component library',
+    company: 'The Knot',
+    period: '2018–2022',
+    description:
+      'Built an internal A/B testing service and REST API for experiments and user bucketing. Led development on a company-wide React component library.',
+    technologies: ['React', 'Next.js', 'Node.js', 'Ruby on Rails', 'Jenkins']
+  }
+];
+
+/** @returns {Record<string, unknown>} */
+export function personJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Veekas Ashoka',
+    url: 'https://veekasmeansprogress.com',
+    email: 'veekas.ashoka@gmail.com',
+    jobTitle: 'Senior Product Engineer',
+    worksFor: {
+      '@type': 'Organization',
+      name: 'SolarAPP+'
+    },
+    description: metaDescription,
+    knowsAbout: [
+      'TypeScript',
+      'React',
+      'Next.js',
+      'Svelte',
+      'Node.js',
+      'GraphQL',
+      'PostgreSQL',
+      'Web Accessibility',
+      'Climate Technology',
+      'Electrification',
+      'LangGraph',
+      'OpenAI API'
+    ],
+    sameAs: [
+      'https://www.linkedin.com/in/veekas',
+      'https://github.com/veekas',
+      'https://allogrow.com'
+    ],
+    alumniOf: [
+      { '@type': 'Organization', name: 'Rewiring America' },
+      { '@type': 'Organization', name: 'Arcadia' },
+      { '@type': 'Organization', name: 'The Knot Worldwide' }
+    ],
+    hasCredential: [
+      {
+        '@type': 'EducationalOccupationalCredential',
+        name: 'Bachelor of Arts in Political Science',
+        educationalLevel: "Bachelor's Degree",
+        credentialCategory: 'degree'
+      }
+    ]
+  };
+}
+
+/** @type {readonly { href: string; label: string; external?: boolean }[]} */
+export const links = [
+  { href: 'https://www.linkedin.com/in/veekas', label: 'linkedin' },
+  { href: 'https://www.github.com/veekas', label: 'github' },
+  { href: 'https://allogrow.com', label: 'allo' },
+  { href: 'https://calendly.com/veekas/meet', label: 'calendar' },
+  { href: 'mailto:fit-imply-given@duck.com', label: 'email', external: false },
+  { href: '/work', label: 'work', external: false },
+  { href: 'https://i.airbuds.fm/veekas/FJLDpeRRL6', label: 'airbuds' },
+  { href: 'http://www.instagram.com/veekas', label: 'instagram' },
+  { href: 'https://app.thestorygraph.com/profile/veekas', label: 'storygraph' },
+  { href: 'https://strava.app.link/gpIRjM032Yb', label: 'strava' }
+];

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,11 +1,1 @@
-import { adminSupabase } from '$lib/server/supabase';
-
-export const load = async () => {
-  const { data } = await adminSupabase
-    .from('content')
-    .select('value')
-    .eq('key', 'bio')
-    .single();
-
-  return { bio: data?.value || '' };
-};
+export const load = async () => ({});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,6 @@
     links,
     metaDescription,
     personJsonLd,
-    shortBio,
-    skills,
     tagline
   } from '$lib/profile.js';
 
@@ -32,14 +30,6 @@
         </h1>
 
         <p class="tagline">{tagline}</p>
-
-        <p class="bio">{shortBio}</p>
-
-        <ul class="skills">
-          {#each skills as skill}
-            <li>{skill}</li>
-          {/each}
-        </ul>
 
         <p class="work-link">
           <a href="/work">more about my work →</a>
@@ -130,39 +120,11 @@
   }
 
   .tagline {
-    color: var(--gold);
     font-size: clamp(0.7rem, 1.8vw, 0.85rem);
     letter-spacing: 0.04em;
-    margin: 0.5vmin 0 0;
+    margin: 1vmin 0 0;
     text-align: left;
     opacity: 0.85;
-  }
-
-  .bio {
-    color: var(--muted);
-    font-size: clamp(0.8rem, 2vw, 1rem);
-    line-height: 1.7;
-    margin: 0.75vmin 0 0;
-    text-align: left;
-    max-width: 36rem;
-  }
-
-  .skills {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    margin: 0.75rem 0 0;
-    padding: 0;
-    list-style: none;
-    justify-content: flex-start;
-  }
-
-  .skills li {
-    font-size: 0.65rem;
-    color: var(--muted);
-    border: 1px solid var(--border);
-    padding: 0.2rem 0.45rem;
-    border-radius: 2px;
   }
 
   .work-link {
@@ -261,16 +223,10 @@
     }
 
     .tagline,
-    .bio,
-    .skills,
     .work-link {
       display: table-caption;
       caption-side: bottom;
       text-align: right;
-    }
-
-    .skills {
-      justify-content: flex-end;
     }
 
     .bottom-left {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,23 +1,25 @@
 <script>
   import { fly } from 'svelte/transition';
   import AudioMessage from '$lib/components/AudioMessage.svelte';
+  import {
+    links,
+    metaDescription,
+    personJsonLd,
+    shortBio,
+    skills,
+    tagline
+  } from '$lib/profile.js';
+
   let { data } = $props();
 
-  const links = [
-    { href: 'https://i.airbuds.fm/veekas/FJLDpeRRL6', label: 'airbuds' },
-    { href: 'https://allogrow.com', label: 'allo' },
-    { href: 'https://calendly.com/veekas/meet', label: 'calendar' },
-    { href: 'mailto:fit-imply-given@duck.com', label: 'email', external: false },
-    { href: 'https://www.github.com/veekas', label: 'github' },
-    { href: 'http://www.instagram.com/veekas', label: 'instagram' },
-    { href: 'https://www.linkedin.com/in/veekas', label: 'linkedin' },
-    { href: 'https://app.thestorygraph.com/profile/veekas', label: 'storygraph' },
-    { href: 'https://strava.app.link/gpIRjM032Yb', label: 'strava' }
-  ];
+  const jsonLd = JSON.stringify(personJsonLd());
 </script>
 
 <svelte:head>
   <title>veekas ashoka</title>
+  <meta name="description" content={metaDescription} />
+  <meta property="og:description" content={metaDescription} />
+  {@html `<script type="application/ld+json">${jsonLd}</script>`}
 </svelte:head>
 
 <main>
@@ -29,15 +31,29 @@
           <span class="shift-right" in:fly={{ y: -75, delay: 1000, duration: 2000 }}>ashoka</span>
         </h1>
 
-        {#if data.bio}
-          <p class="bio">{data.bio}</p>
-        {/if}
+        <p class="tagline">{tagline}</p>
+
+        <p class="bio">{shortBio}</p>
+
+        <ul class="skills">
+          {#each skills as skill}
+            <li>{skill}</li>
+          {/each}
+        </ul>
+
+        <p class="work-link">
+          <a href="/work">more about my work →</a>
+        </p>
       </div>
 
       <div class="bottom-left">
         <div class="links links--mobile">
           {#each links as link}
-            <a href={link.href} rel="me" target={link.external === false ? undefined : '_blank'}>{link.label}</a>
+            <a
+              href={link.href}
+              rel={link.href.startsWith('http') ? 'me' : undefined}
+              target={link.external === false ? undefined : '_blank'}
+            >{link.label}</a>
           {/each}
         </div>
 
@@ -59,7 +75,11 @@
 
     <div class="links links--desktop">
       {#each links as link}
-        <a href={link.href} rel="me" target={link.external === false ? undefined : '_blank'}>{link.label}</a>
+        <a
+          href={link.href}
+          rel={link.href.startsWith('http') ? 'me' : undefined}
+          target={link.external === false ? undefined : '_blank'}>{link.label}</a
+        >
       {/each}
     </div>
   </div>
@@ -109,12 +129,50 @@
     padding-left: 4ch;
   }
 
+  .tagline {
+    color: var(--gold);
+    font-size: clamp(0.7rem, 1.8vw, 0.85rem);
+    letter-spacing: 0.04em;
+    margin: 0.5vmin 0 0;
+    text-align: left;
+    opacity: 0.85;
+  }
+
   .bio {
     color: var(--muted);
     font-size: clamp(0.8rem, 2vw, 1rem);
     line-height: 1.7;
     margin: 0.75vmin 0 0;
     text-align: left;
+    max-width: 36rem;
+  }
+
+  .skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0.75rem 0 0;
+    padding: 0;
+    list-style: none;
+    justify-content: flex-start;
+  }
+
+  .skills li {
+    font-size: 0.65rem;
+    color: var(--muted);
+    border: 1px solid var(--border);
+    padding: 0.2rem 0.45rem;
+    border-radius: 2px;
+  }
+
+  .work-link {
+    margin: 0.75rem 0 0;
+    text-align: left;
+    font-size: 0.8rem;
+  }
+
+  .work-link a {
+    color: var(--gold);
   }
 
   .links {
@@ -202,10 +260,17 @@
       align-self: stretch;
     }
 
-    .bio {
+    .tagline,
+    .bio,
+    .skills,
+    .work-link {
       display: table-caption;
       caption-side: bottom;
       text-align: right;
+    }
+
+    .skills {
+      justify-content: flex-end;
     }
 
     .bottom-left {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -19,7 +19,7 @@
     <h2>bio</h2>
     <form method="POST" action="?/updateBio" use:enhance class="section-form">
       <label>
-        bio (shown on public landing page)
+        bio (legacy — landing page copy lives in src/lib/profile.js)
         <textarea name="bio" rows="3">{data.content.bio || ''}</textarea>
       </label>
       {#if form?.bioSaved}

--- a/src/routes/request-access/+page.svelte
+++ b/src/routes/request-access/+page.svelte
@@ -27,8 +27,19 @@
       </div>
     {:else}
       <p class="hint">
-        if you know veekas, enter your info below to request access to his private feed.
+        if you know veekas, enter your info below to request access to his private feed — a
+        low-key update page for friends, not a social network.
       </p>
+
+      <div class="feed-preview">
+        <p class="feed-preview-label">what's inside</p>
+        <ul>
+          <li><strong>what i'm up to</strong> — occasional life and work updates</li>
+          <li><strong>what i'm reading</strong> — books in progress, with notes when there's something worth sharing</li>
+          <li><strong>proof of life</strong> — photos so you know he's still out there</li>
+          <li><strong>contact info</strong> — email, phone, and mailing address for people who should have it</li>
+        </ul>
+      </div>
 
       <form
         method="POST"
@@ -101,7 +112,7 @@
 
   .card {
     width: 100%;
-    max-width: 360px;
+    max-width: 400px;
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
@@ -119,6 +130,40 @@
     font-size: 0.85rem;
     margin: 0;
     line-height: 1.6;
+  }
+
+  .feed-preview {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    padding: 1rem 1.1rem;
+    border-radius: 2px;
+  }
+
+  .feed-preview-label {
+    margin: 0 0 0.65rem;
+    font-size: 0.7rem;
+    color: var(--gold);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  .feed-preview ul {
+    margin: 0;
+    padding: 0 0 0 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+
+  .feed-preview li {
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.55;
+  }
+
+  .feed-preview strong {
+    color: var(--text);
+    font-weight: 600;
   }
 
   form {

--- a/src/routes/work/+page.svelte
+++ b/src/routes/work/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import ProjectCard from '$lib/components/ProjectCard.svelte';
-  import { metaDescription, projects, skills } from '$lib/profile.js';
+  import { metaDescription, projects, shortBio, skills } from '$lib/profile.js';
 </script>
 
 <svelte:head>
@@ -14,10 +14,7 @@
   <header>
     <a href="/" class="back">← home</a>
     <h1>work</h1>
-    <p class="intro">
-      Seven years building full-stack web products — lately in climate tech and AI-supported tools.
-      Currently at <strong>SolarAPP+</strong>; previously Rewiring America, Arcadia, and The Knot.
-    </p>
+    <p class="bio">{shortBio}</p>
     <ul class="skills">
       {#each skills as skill}
         <li>{skill}</li>
@@ -79,17 +76,12 @@
     margin: 0 0 1.25rem;
   }
 
-  .intro {
+  .bio {
     color: var(--muted);
     font-size: 0.95rem;
     line-height: 1.7;
     margin: 0 0 1.25rem;
     max-width: 40rem;
-  }
-
-  .intro strong {
-    color: var(--text);
-    font-weight: 600;
   }
 
   .skills {

--- a/src/routes/work/+page.svelte
+++ b/src/routes/work/+page.svelte
@@ -1,0 +1,134 @@
+<script>
+  import ProjectCard from '$lib/components/ProjectCard.svelte';
+  import { metaDescription, projects, skills } from '$lib/profile.js';
+</script>
+
+<svelte:head>
+  <title>work — veekasmeansprogress.com</title>
+  <meta name="description" content={metaDescription} />
+  <meta property="og:title" content="work — veekas ashoka" />
+  <meta property="og:description" content={metaDescription} />
+</svelte:head>
+
+<main>
+  <header>
+    <a href="/" class="back">← home</a>
+    <h1>work</h1>
+    <p class="intro">
+      Seven years building full-stack web products — lately in climate tech and AI-supported tools.
+      Currently at <strong>SolarAPP+</strong>; previously Rewiring America, Arcadia, and The Knot.
+    </p>
+    <ul class="skills">
+      {#each skills as skill}
+        <li>{skill}</li>
+      {/each}
+    </ul>
+  </header>
+
+  <section class="projects">
+    <h2>selected projects</h2>
+    <div class="grid">
+      {#each projects as project}
+        <ProjectCard {...project} />
+      {/each}
+    </div>
+  </section>
+
+  <footer>
+    <p>
+      full résumé on
+      <a href="https://www.linkedin.com/in/veekas" rel="me" target="_blank">linkedin</a>
+      ·
+      <a href="https://calendly.com/veekas/meet" target="_blank">grab time on my calendar</a>
+    </p>
+  </footer>
+</main>
+
+<style>
+  main {
+    max-width: 52rem;
+    margin: 0 auto;
+    padding: 3rem 2rem 4rem;
+  }
+
+  .back {
+    display: inline-block;
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-bottom: 2rem;
+  }
+
+  .back:hover {
+    color: var(--gold);
+  }
+
+  h1 {
+    color: var(--gold);
+    font-size: clamp(2rem, 6vw, 3rem);
+    font-weight: 600;
+    margin: 0 0 1rem;
+    line-height: 1.1;
+  }
+
+  h2 {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--muted);
+    text-transform: lowercase;
+    letter-spacing: 0.08em;
+    margin: 0 0 1.25rem;
+  }
+
+  .intro {
+    color: var(--muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+    margin: 0 0 1.25rem;
+    max-width: 40rem;
+  }
+
+  .intro strong {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 0 3rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .skills li {
+    font-size: 0.7rem;
+    color: var(--gold);
+    border: 1px solid var(--border);
+    padding: 0.25rem 0.55rem;
+    border-radius: 2px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 20rem), 1fr));
+    gap: 1rem;
+  }
+
+  footer {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+  }
+
+  footer p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+    line-height: 1.6;
+  }
+
+  footer a {
+    color: var(--text);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Adds a `/work` page with six resume-backed project cards (Rewiring America, Allo, freelance healthcare work, Arcadia, The Knot)
- Refreshes landing page with a short bio, tagline, skills tags, and link to `/work` — keeps the casual layout and audio hello
- Adds Schema.org JSON-LD, updated meta/OG descriptions, and reorders links (LinkedIn, GitHub, Allo, calendar first)
- Centralizes professional copy in `src/lib/profile.js` for easy updates

## Notes
- Resume (Dec 2025) used as primary source for project descriptions; SolarAPP+ included as current role from live bio
- Admin bio field kept but noted as legacy — landing copy now lives in `profile.js`

## Test plan
- [ ] Visit `/` — tagline, short bio, skills, and "more about my work →" link render correctly
- [ ] Visit `/work` — six project cards display with hover states
- [ ] Confirm link order: linkedin → github → allo → calendar → email → work → personal links
- [ ] View page source — JSON-LD Person schema present on landing page
- [ ] Check mobile layout — bio/skills don't break the fixed bottom bar
- [ ] Run Google Rich Results Test on deploy preview